### PR TITLE
Added some resiliency to long lived service

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords :
   - Go
   - Logging
   - Simple
-version : 1.0.0
+version : 1.0.1
 author : davidjohngee
 email : david.gee@ipengineer.net


### PR DESCRIPTION
Added try/except blocks to the API calls to ghost2logger. This provides some resiliency in case Ghost2logger has not been started or is being replaced. This means in turn, you do not have to restart the sensor components to replace or do maintenance with the Ghost2logger service that is not part of ST2.