### PR TITLE
Ghost2logger bug fixes, sensor and loopback minor changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,3 +8,9 @@
 
 - New changes made to Ghost2logger binary that allows a regular expression as a host entry as well as message.
 - Config changes made, rendering this version not backwards compatible. Please generate a new configuration (or at least copy and paste across the items.)
+
+## 1.1.1
+
+- Bug fixes to Ghost2logger-X Go binary: Gracefully handles regular expression faults without faulting, better logging for internal goings on
+- Bug fixes to ghostloggersensor - casting string to int for port number and turned down logging verbosity
+- Compatible with 2.5x of ST2 and retains backwards compatibility

--- a/bin/ghost2logger.service
+++ b/bin/ghost2logger.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/StackStorm-Exchange/ghost2logger
 
 [Service]
 Type=simple
-ExecStart=/opt/stackstorm/packs/ghost2logger/bin/ghost2logger-linux-x64-service-0.5 -cfg /opt/stackstorm/configs/ghost2logger.yaml
+ExecStart=/opt/stackstorm/packs/ghost2logger/bin/ghost2logger-linux-x64-service-0.6 -cfg /opt/stackstorm/configs/ghost2logger.yaml
 StandardOutput=null
 Restart=on-failure
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,9 +4,11 @@ name : ghost2logger
 description : Syslog end-point for match rule criteria
 keywords :
   - Syslog
+  - syslog
   - Go
   - Logging
-  - Simple
-version : 1.1.0
+  - logging
+  - useful
+version : 1.1.1
 author : davidjohngee
 email : david.gee@ipengineer.net

--- a/sensors/ghost2loggerloopback.py
+++ b/sensors/ghost2loggerloopback.py
@@ -123,7 +123,8 @@ class Ghost2loggerLoopback(PollingSensor):
         try:
             # Sort rules in to rule dictionary
             for _rule in rules_payload:
-                self._logger.info(_rule)
+                # Uncomment line below for debugging
+                # self._logger.info(_rule)
                 _host = _rule['criteria']['trigger.host']['pattern']
                 if _host in _new:
                     _new[_host].append(_rule['criteria']['trigger.pattern']

--- a/sensors/ghost2loggersensor.py
+++ b/sensors/ghost2loggersensor.py
@@ -71,7 +71,7 @@ class Ghost2loggerSensor(Sensor):
                                                   '0.0.0.0')
 
         self._sensor_listen_port = self._config.get('sensor_listen_port',
-                                                    '12021')
+                                                    '12022')
 
         self._username = self._config.get('username', 'admin')
         self._password = self._config.get('password', 'admin')
@@ -119,7 +119,7 @@ class Ghost2loggerSensor(Sensor):
         self._logger.info('[Ghost2logger]: Calling Flask App')
 
         self._app.run(host=self._sensor_listen_ip,
-                      port=self._sensor_listen_port)
+                      port=int(self._sensor_listen_port))
 
     def cleanup(self):
         """Stuff."""
@@ -138,7 +138,7 @@ class Ghost2loggerSensor(Sensor):
         pass
 
     def _process_request(self, request):
-        self._logger.info('[Ghost2logger]: Received Request')
+        self._logger.info('[Ghost2logger]: Received Matched Syslog Event')
         if request.headers['Content-Type'] == 'application/json':
             payload = request.json
             if 'pattern' and 'host' and 'hostpattern' and 'message' in payload:


### PR DESCRIPTION
Bug fixes to ghost2logger binary:
- Better handling of faulty regular expressions

Bug fixes to ghost2loggersensor:
- Type cast from string to int for port number

Changed systemd service file to reference new binary version.
Bumped pack version.
